### PR TITLE
French translation & size correction for long titles on hidden sidebar

### DIFF
--- a/assets/stylesheets/documents.css
+++ b/assets/stylesheets/documents.css
@@ -1,15 +1,15 @@
 td.contentDoc.wiki {
-	width: 100%;
-        text-align: left;
+	width: 75%;
+	text-align: left;
 }
 
 td.subjectDoc {
-     min-width: 200px;
-text-align: left!important;
+	min-width: 200px;
+	width: 25%;
+	text-align: left!important;
 }
 
 td.createdDoc {
 	min-width: 140px;
 }
-
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,5 @@
+en:
+  label_redmine_documents_title: Titre
+  label_redmine_documents_content: Description
+  label_redmine_documents_created: Créé le
+

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,4 @@
-en:
+fr:
   label_redmine_documents_title: Titre
   label_redmine_documents_content: Description
   label_redmine_documents_created: Créé le


### PR DESCRIPTION
Added french translation.
Changed the CSS to better accomodate long titles, especially when the sidebar is hidden (so titles receive some more space, compared to description).